### PR TITLE
feat: rawBody parsing for webhook

### DIFF
--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -54,6 +54,9 @@ class Server {
       })
     }
     const jsonOpt = limitOpt ? { limit: limitOpt } : {}
+    jsonOpt.verify = (req, res, buf) => {
+      req.rawBody = buf.toString();
+    }
     app.use(json(jsonOpt), bodyParserErrorHandler())
 
     const conn = app.listen(

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -56,7 +56,7 @@ class Server {
     }
     const jsonOpt = limitOpt ? { limit: limitOpt } : {}
 
-    // add rawBody key for webhook parsing, if raw is true
+    // add rawBody key for webhook parsing, if rawBodyOpt is true
     if (rawBodyOpt) {
       jsonOpt.verify = (req, res, buf) => {
         req.rawBody = buf.toString();

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -59,7 +59,7 @@ class Server {
     // add rawBody key for webhook parsing, if rawBodyOpt is true
     if (rawBodyOpt) {
       jsonOpt.verify = (req, res, buf) => {
-        req.rawBody = buf.toString();
+        req.rawBody = buf.toString()
       }
     }
 

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -23,7 +23,7 @@ class Server {
       limit: limitOpt,
       logSkipPath: logSkipPathOpt,
       logRequest: logRequestOpt,
-      raw
+      raw: rawOpt
     } = option
 
     const app = express()
@@ -57,7 +57,7 @@ class Server {
     const jsonOpt = limitOpt ? { limit: limitOpt } : {}
 
     // add rawBody key for webhook parsing, if raw is true
-    if (raw) {
+    if (rawOpt) {
       jsonOpt.verify = (req, res, buf) => {
         req.rawBody = buf.toString();
       }

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -54,6 +54,8 @@ class Server {
       })
     }
     const jsonOpt = limitOpt ? { limit: limitOpt } : {}
+
+    // rawBody for webhook parsing
     jsonOpt.verify = (req, res, buf) => {
       req.rawBody = buf.toString();
     }

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -22,7 +22,8 @@ class Server {
       ping: pingOpt,
       limit: limitOpt,
       logSkipPath: logSkipPathOpt,
-      logRequest: logRequestOpt
+      logRequest: logRequestOpt,
+      raw
     } = option
 
     const app = express()
@@ -55,10 +56,13 @@ class Server {
     }
     const jsonOpt = limitOpt ? { limit: limitOpt } : {}
 
-    // rawBody for webhook parsing
-    jsonOpt.verify = (req, res, buf) => {
-      req.rawBody = buf.toString();
+    // add rawBody key for webhook parsing, if raw is true
+    if (raw) {
+      jsonOpt.verify = (req, res, buf) => {
+        req.rawBody = buf.toString();
+      }
     }
+
     app.use(json(jsonOpt), bodyParserErrorHandler())
 
     const conn = app.listen(

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -23,7 +23,7 @@ class Server {
       limit: limitOpt,
       logSkipPath: logSkipPathOpt,
       logRequest: logRequestOpt,
-      raw: rawOpt
+      rawReqBody: rawBodyOpt
     } = option
 
     const app = express()
@@ -57,7 +57,7 @@ class Server {
     const jsonOpt = limitOpt ? { limit: limitOpt } : {}
 
     // add rawBody key for webhook parsing, if raw is true
-    if (rawOpt) {
+    if (rawBodyOpt) {
       jsonOpt.verify = (req, res, buf) => {
         req.rawBody = buf.toString();
       }

--- a/lib/http/server/index.js
+++ b/lib/http/server/index.js
@@ -23,7 +23,7 @@ class Server {
       limit: limitOpt,
       logSkipPath: logSkipPathOpt,
       logRequest: logRequestOpt,
-      rawReqBody: rawBodyOpt
+      rawBody: rawBodyOpt
     } = option
 
     const app = express()

--- a/lib/http/server/test/server.test.js
+++ b/lib/http/server/test/server.test.js
@@ -72,4 +72,20 @@ describe('http server tests', () => {
         done()
       })
   })
+  test('rawBody true should populate request with rawBody key and value', (done) => {
+    const server = new Server(null, { rawBody: true })
+    server.app.post('/', (req, res) => {
+      const rawBody = req.rawBody
+      return res.status(200).json({ rawBody })
+    })
+    const mockReq = { value: 'testValue' }
+    request(server.app)
+      .post('/')
+      .send(mockReq)
+      .then(res => {
+        expect(res._body.rawBody).toBe(JSON.stringify(mockReq))
+        server.conn.close()
+        done()
+      })
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -430,7 +430,7 @@
     },
     "lib/http/server": {
       "name": "@kelchy/http-server",
-      "version": "0.1.4",
+      "version": "0.2.3",
       "license": "GPLv3",
       "dependencies": {
         "@kelchy/common": "^1.0.1",


### PR DESCRIPTION
Added an additional key to the json parser from body-parser to allow the initial raw bodies of webhook calls from (eg.stripe) to be parsed so that they can be identified by the webhook controller. Added this additional key will not affect the main json body and hence other calls.